### PR TITLE
Fix bytes parsing for multi byte types

### DIFF
--- a/src/CombinedParsers.jl
+++ b/src/CombinedParsers.jl
@@ -485,7 +485,7 @@ struct Bytes{T} <: CombinedParser{MatchState,T}
 end
 Bytes(N::Integer, T::Type=Char) = Bytes{T}(N)
 _iterate(parser::Bytes, sequence, till, posi, next_i, state::Nothing) =
-    posi+parser.N <= till ? (nextind(sequence,posi,parser.N), MatchState()) : nothing
+    posi+parser.N <= (till+1) ? (nextind(sequence,posi,parser.N), MatchState()) : nothing
 _iterate(parser::Bytes, sequence, till, posi, next_i, state::MatchState) =
     nothing
 regex_string_(x::Bytes{N}) where N = ".{$(N)}"

--- a/src/CombinedParsers.jl
+++ b/src/CombinedParsers.jl
@@ -469,7 +469,7 @@ end
 
 
 
-export Bytes
+export Bytes, bigEndian, littleEndian
 "Abstract type for stepping with previndex/nextindex, accounting for ncodeunit length of chars at point."
 abstract type NIndexParser{N,T} <: LeafParser{MatchState,T} end
 """
@@ -480,17 +480,22 @@ Fast parsing of a fixed number `N` of indices,
 
 Provide `Base.get(parser::Bytes{N,T}, sequence, till, after, i, state) where {N,T}` for custom conversion.
 """
+@enum endianType begin
+    bigEndian
+    littleEndian
+end
 struct Bytes{T} <: CombinedParser{MatchState,T}
     N::Int
+    endian::endianType
 end
-Bytes(N::Integer, T::Type=Char) = Bytes{T}(N)
+Bytes(N::Integer, T::Type=Char,endian::endianType=littleEndian) = Bytes{T}(N, endian)
 _iterate(parser::Bytes, sequence, till, posi, next_i, state::Nothing) =
     posi+parser.N <= (till+1) ? (nextind(sequence,posi,parser.N), MatchState()) : nothing
 _iterate(parser::Bytes, sequence, till, posi, next_i, state::MatchState) =
     nothing
 regex_string_(x::Bytes{N}) where N = ".{$(N)}"
 Base.show(io::IO, x::Bytes) =
-    print(io, "$(x.N) Bytes::$(result_type(x))")
+    print(io, "$(x.N) Bytes::$(result_type(x)) $(x.endian)")
 @inline prevind(str,i::Int,parser::Bytes,x) =
     prevind(str,i,parser.N)
 @inline nextind(str,i::Int,parser::Bytes,x) =

--- a/src/get.jl
+++ b/src/get.jl
@@ -28,7 +28,12 @@ end
 function Base.get(parser::Bytes{T}, sequence::Vector{UInt8}, till,
                   after, i, state) where {T}
     if isbitstype(T)
-        reinterpret(T,sequence[i:after-1])[1]
+        if parser.endian == bigEndian
+            b = sequence[after-1:-1:i]
+        else
+            b = sequence[i:after-1]
+        end
+        reinterpret(T,b)[1]
     else
         T(sequence[i:after-1])
     end

--- a/test/test-parser.jl
+++ b/test/test-parser.jl
@@ -54,9 +54,13 @@ end
     dat = 'a'^(new_Repeat_max)*'b';
     @test String(parse(Repeat_stop('a','b';max=new_Repeat_max), dat))==dat[1:end-1]
 end
+@testset "Bytes" begin
+    # simple test for binary parsing
+    @test parse(Bytes(1,UInt8),[0x33]) == 0x33
+    @test parse(Bytes(2,UInt16),[0x33,0x66]) == 0x6633
+    @test parse(Bytes(4,Float32),[0x55,0x77,0x33,0x66]) == reinterpret(Float32,0x66337755)
 end
-
-
+end
 
 @testset "FlatMap" begin
     @test parse(

--- a/test/test-parser.jl
+++ b/test/test-parser.jl
@@ -60,6 +60,13 @@ end
     @test parse(Bytes(2,UInt16),[0x33,0x66]) == 0x6633
     @test parse(Bytes(4,Float32),[0x55,0x77,0x33,0x66]) == reinterpret(Float32,0x66337755)
 end
+@testset "Endianness" begin
+    # default should be little endian
+    @test parse(Bytes(2,UInt16),[0x22,0x33]) == 0x3322
+    # check each endian ness
+    @test parse(Bytes(2,UInt16,littleEndian), [0x22,0x33]) == 0x3322
+    @test parse(Bytes(2,UInt16,bigEndian), [0x22,0x33]) == 0x2233
+end
 end
 
 @testset "FlatMap" begin


### PR DESCRIPTION
Parsing multi byte objects fails (see added tests) due to https://github.com/gkappler/CombinedParsers.jl/commit/7707b8b046aff330efabd1ad158a5e898a918b54