### PR TITLE
Fix failing case of Bytes parser when there is only 1 byte in the stream

### DIFF
--- a/src/CombinedParsers.jl
+++ b/src/CombinedParsers.jl
@@ -494,8 +494,8 @@ end
 If available before end of sequence, parse `N` bytes successfully with `result_type` `T`, fail otherwise.
 """
 Bytes(N::Integer, T::Type=Vector{UInt8}) = Bytes{T}(N)
-_iterate(parser::Bytes, sequence, till, posi, next_i, state::Nothing) =
-    posi+parser.N <= till ? (nextind(sequence,posi,parser.N), MatchState()) : nothing
+_iterate(parser::Bytes, sequence, till, posi, next_i, state::Nothing) = 
+    posi+parser.N <= till+1 ? (nextind(sequence,posi,parser.N), MatchState()) : nothing
 _iterate(parser::Bytes, sequence, till, posi, next_i, state::MatchState) =
     nothing
 regex_string_(x::Bytes{N}) where N = ".{$(N)}"

--- a/test/test-parser.jl
+++ b/test/test-parser.jl
@@ -54,9 +54,14 @@ end
     dat = 'a'^(new_Repeat_max)*'b';
     @test String(parse(Repeat_stop('a','b';max=new_Repeat_max), dat))==dat[1:end-1]
 end
+
+@testset "Bytes" begin
+    # simple test for binary parsing
+    @test parse(Bytes(1,UInt8),[0x33]) == 0x33
+    @test parse(Bytes(2,UInt16),[0x33,0x66]) == 0x6633
+    @test parse(Bytes(4,Float32),[0x55,0x77,0x33,0x66]) == reinterpret(Float32,0x66337755)
 end
-
-
+end
 
 @testset "FlatMap" begin
     @test parse(


### PR DESCRIPTION
I've added a few bytes test cases and made a separate pull request for this issue. 