### PR TITLE
Bytes endian transformation experimental implementation

### DIFF
--- a/src/CombinedParsers.jl
+++ b/src/CombinedParsers.jl
@@ -494,8 +494,8 @@ end
 If available before end of sequence, parse `N` bytes successfully with `result_type` `T`, fail otherwise.
 """
 Bytes(N::Integer, T::Type=Vector{UInt8}) = Bytes{T}(N)
-_iterate(parser::Bytes, sequence, till, posi, next_i, state::Nothing) =
-    posi+parser.N <= till ? (nextind(sequence,posi,parser.N), MatchState()) : nothing
+_iterate(parser::Bytes, sequence, till, posi, next_i, state::Nothing) = 
+    posi+parser.N <= till+1 ? (nextind(sequence,posi,parser.N), MatchState()) : nothing
 _iterate(parser::Bytes, sequence, till, posi, next_i, state::MatchState) =
     nothing
 regex_string_(x::Bytes{N}) where N = ".{$(N)}"

--- a/src/get.jl
+++ b/src/get.jl
@@ -307,7 +307,18 @@ function Base.get(parser::Transformation{MatchRange}, sequence, till, after, i, 
     i:prevind(sequence,after)
 end
 
+export ByteSwap
+struct ByteSwap
+end
 
+function Base.map(b::ByteSwap, p::AbstractToken)
+    T = result_type(p)
+    Transformation{T}(b,p)
+end
+function Base.get(parser::Transformation{ByteSwap}, sequence, till, after, i, state)
+    v = get(parser.parser,sequence, till, after, i, state)
+    bswap(v)
+end
 
 """
 A Transformation{<:Constant} skips evaluation of get(.parser).

--- a/test/test-parser.jl
+++ b/test/test-parser.jl
@@ -61,6 +61,12 @@ end
     @test parse(Bytes(2,UInt16),[0x33,0x66]) == 0x6633
     @test parse(Bytes(4,Float32),[0x55,0x77,0x33,0x66]) == reinterpret(Float32,0x66337755)
 end
+
+@testset "ByteSwap" begin
+    # Usually CombinedParsers will parse in big endian but to convert to little ending we can do a ByteSwap
+    @test parse(map(ByteSwap(), Bytes(2,UInt16)),[0x33,0x66]) == 0x3366
+    @test parse(map(ByteSwap(), Bytes(4,Float32)),[0x55,0x77,0x33,0x66]) == reinterpret(Float32,0x55773366)
+end
 end
 
 @testset "FlatMap" begin

--- a/test/test-parser.jl
+++ b/test/test-parser.jl
@@ -54,9 +54,14 @@ end
     dat = 'a'^(new_Repeat_max)*'b';
     @test String(parse(Repeat_stop('a','b';max=new_Repeat_max), dat))==dat[1:end-1]
 end
+
+@testset "Bytes" begin
+    # simple test for binary parsing
+    @test parse(Bytes(1,UInt8),[0x33]) == 0x33
+    @test parse(Bytes(2,UInt16),[0x33,0x66]) == 0x6633
+    @test parse(Bytes(4,Float32),[0x55,0x77,0x33,0x66]) == reinterpret(Float32,0x66337755)
 end
-
-
+end
 
 @testset "FlatMap" begin
     @test parse(


### PR DESCRIPTION
Hi, I created this quick implementation of byteswap as transformation. But honestly benchmarking it against bswap shows we don't have any advantage in terms of performance
```

julia> using BenchmarkTools

julia> p1 = map(bswap, Bytes(4,Float32))
 Bytes |> map(bswap)
::Float32

julia> @btime parse(p1, [0x33,0x35,0x11,0x33])
  97.881 ns (3 allocations: 208 bytes)
4.215799f-8

julia> p2 = map(ByteSwap(), Bytes(4,Float32))
 Bytes |> map(ByteSwap())
::Float32

julia> @btime parse(p2, [0x33,0x35,0x11,0x33])
  103.404 ns (3 allocations: 208 bytes)
4.215799f-8
```
